### PR TITLE
feat: enhance SEO with comprehensive metadata, i18n support, and accessibility improvements

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -103,7 +103,7 @@
     "category": "Category",
     "description": "Description",
     "metaTitle": "{name} - Tech Community in {province}",
-    "metaDescription": "Connect with {name}, a {category} tech community in {province}. {description}",
+    "metaDescription": "Connect with {name}, a {category} community in {province}. {description}",
     "notFoundTitle": "Community",
     "notFoundSubtitle": "Not Found",
     "notFoundDescription": "The community you are looking for doesn't exist or has been deleted.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -44,6 +44,8 @@
   "Communities": {
     "title": "Tech Communities",
     "subtitle": "Discover and connect with tech communities across Spain",
+    "metaTitle": "Tech Communities in Spain | TechHubs Spain",
+    "metaDescription": "Discover and connect with the best tech communities across Spain. Find meetups, events, and networking opportunities in your area.",
     "viewDetails": "View details",
     "filter": "All",
     "filterByProvince": "Filter by province",
@@ -100,6 +102,8 @@
     "location": "Location",
     "category": "Category",
     "description": "Description",
+    "metaTitle": "{name} - Tech Community in {province}",
+    "metaDescription": "Connect with {name}, a {category} tech community in {province}. {description}",
     "notFoundTitle": "Community",
     "notFoundSubtitle": "Not Found",
     "notFoundDescription": "The community you are looking for doesn't exist or has been deleted.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -44,7 +44,7 @@
   "Communities": {
     "title": "Tech Communities",
     "subtitle": "Discover and connect with tech communities across Spain",
-    "metaTitle": "Tech Communities in Spain | TechHubs Spain",
+    "metaTitle": "Tech Communities in Spain",
     "metaDescription": "Discover and connect with the best tech communities across Spain. Find meetups, events, and networking opportunities in your area.",
     "viewDetails": "View details",
     "filter": "All",

--- a/messages/es.json
+++ b/messages/es.json
@@ -44,7 +44,7 @@
   "Communities": {
     "title": "Comunidades Tech",
     "subtitle": "Descubre y conecta con comunidades tecnológicas en España",
-    "metaTitle": "Comunidades Tech en España | TechHubs España",
+    "metaTitle": "Comunidades Tech en España",
     "metaDescription": "Descubre y conecta con las mejores comunidades tecnológicas de España. Encuentra meetups, eventos y oportunidades de networking en tu área.",
     "viewDetails": "Ver detalles",
     "filter": "Todo",

--- a/messages/es.json
+++ b/messages/es.json
@@ -44,6 +44,8 @@
   "Communities": {
     "title": "Comunidades Tech",
     "subtitle": "Descubre y conecta con comunidades tecnológicas en España",
+    "metaTitle": "Comunidades Tech en España | TechHubs España",
+    "metaDescription": "Descubre y conecta con las mejores comunidades tecnológicas de España. Encuentra meetups, eventos y oportunidades de networking en tu área.",
     "viewDetails": "Ver detalles",
     "filter": "Todo",
     "filterByProvince": "Filtrar por provincia",
@@ -100,6 +102,8 @@
     "location": "Ubicación",
     "category": "Categoría",
     "description": "Descripción",
+    "metaTitle": "{name} - Comunidad Tech en {province}",
+    "metaDescription": "Conecta con {name}, una comunidad tecnológica de {category} en {province}. {description}",
     "notFoundTitle": "Comunidad",
     "notFoundSubtitle": "No encontrada",
     "notFoundDescription": "La comunidad que estás buscando no existe o ha sido eliminada.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -103,7 +103,7 @@
     "category": "Categoría",
     "description": "Descripción",
     "metaTitle": "{name} - Comunidad Tech en {province}",
-    "metaDescription": "Conecta con {name}, una comunidad tecnológica de {category} en {province}. {description}",
+    "metaDescription": "Conecta con {name}, una comunidad de {category} en {province}. {description}",
     "notFoundTitle": "Comunidad",
     "notFoundSubtitle": "No encontrada",
     "notFoundDescription": "La comunidad que estás buscando no existe o ha sido eliminada.",

--- a/src/app/[locale]/(index)/_components/community-list/description.tsx
+++ b/src/app/[locale]/(index)/_components/community-list/description.tsx
@@ -6,7 +6,7 @@ import { Community } from "@/types/community";
 export function CommunityDescription({ community }: { community: Community }) {
   return (
     <div className="h-full bg-card/30 backdrop-blur-sm rounded-lg border border-border/50 p-4 flex flex-col justify-between">
-      <p className="text-sm text-gray-600 leading-relaxed line-clamp-3">
+      <p className="text-sm text-muted-foreground leading-relaxed line-clamp-3">
         {community.shortDescription}
       </p>
       <div className="flex justify-end space-x-2 pt-2">

--- a/src/app/[locale]/(index)/_components/community-list/info.tsx
+++ b/src/app/[locale]/(index)/_components/community-list/info.tsx
@@ -9,7 +9,7 @@ export function CommunityInfo({ community }: { community: Community }) {
         <h3 className="text-lg font-semibold tracking-tight">
           {community.name}
         </h3>
-        <p className="text-sm text-gray-600 flex items-center gap-1">
+        <p className="text-sm text-muted-foreground flex items-center gap-1">
           <MapPin className="h-3 w-3" />
           {community.province}
         </p>

--- a/src/app/[locale]/(index)/loading.tsx
+++ b/src/app/[locale]/(index)/loading.tsx
@@ -20,7 +20,7 @@ export default function HomePageLoading() {
                     Spain
                   </span>
                 </h1>
-                <h2 className="text-lg sm:text-xl text-gray-600 max-w-prose">
+                <h2 className="text-lg sm:text-xl text-muted-foreground max-w-prose">
                   Discover and connect with tech enthusiasts across the country
                 </h2>
                 <div className="pt-2">

--- a/src/app/[locale]/(index)/page.client.tsx
+++ b/src/app/[locale]/(index)/page.client.tsx
@@ -42,7 +42,7 @@ export default function HomePageClient({ communities }: HomePageClientProps) {
                 {t("country")}
               </span>
             </h1>
-            <h2 className="text-lg sm:text-xl text-gray-600 max-w-prose">
+            <h2 className="text-lg sm:text-xl text-muted-foreground max-w-prose">
               {t("subtitle")}
             </h2>
             <div className="pt-2">

--- a/src/app/[locale]/(marketing)/about/page.client.tsx
+++ b/src/app/[locale]/(marketing)/about/page.client.tsx
@@ -56,7 +56,7 @@ export default function AboutPageClient({
           <h2 className="text-4xl md:text-5xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent">
             {title}
           </h2>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">{subtitle}</p>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">{subtitle}</p>
         </motion.div>
 
         <motion.div
@@ -65,10 +65,10 @@ export default function AboutPageClient({
         >
           <div className="space-y-8">
             <div className="space-y-6">
-              <p className="text-lg text-gray-600 leading-relaxed">
+              <p className="text-lg text-muted-foreground leading-relaxed">
                 {description1}
               </p>
-              <p className="text-lg text-gray-600 leading-relaxed">
+              <p className="text-lg text-muted-foreground leading-relaxed">
                 {description2}
               </p>
             </div>
@@ -78,13 +78,13 @@ export default function AboutPageClient({
                 <h3 className="text-xl font-semibold text-foreground">
                   {mission}
                 </h3>
-                <p className="text-gray-600">{missionText}</p>
+                <p className="text-muted-foreground">{missionText}</p>
               </div>
               <div className="space-y-4">
                 <h3 className="text-xl font-semibold text-foreground">
                   {vision}
                 </h3>
-                <p className="text-gray-600">{visionText}</p>
+                <p className="text-muted-foreground">{visionText}</p>
               </div>
             </div>
 
@@ -93,7 +93,9 @@ export default function AboutPageClient({
                 <h3 className="text-xl font-semibold text-foreground">
                   {joinUs}
                 </h3>
-                <p className="text-gray-600 max-w-2xl mx-auto">{joinUsText}</p>
+                <p className="text-muted-foreground max-w-2xl mx-auto">
+                  {joinUsText}
+                </p>
                 <Button
                   asChild
                   variant="outline"

--- a/src/app/[locale]/(marketing)/contact/page.client.tsx
+++ b/src/app/[locale]/(marketing)/contact/page.client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { motion } from "motion/react";
-import { Mail, Twitter, Github, ArrowUpRight } from "lucide-react";
+import { Mail, Github, ArrowUpRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import XformerlyTwitter from "@/components/icons/x-formerly-twitter";
 
 interface ContactPageClientProps {
   title: string;
@@ -42,8 +43,8 @@ export default function ContactPageClient({
     {
       title: twitter,
       description: "@techhubses",
-      href: "https://twitter.com/techhubses",
-      icon: Twitter,
+      href: "https://x.com/techhubses",
+      icon: XformerlyTwitter,
     },
     {
       title: github,
@@ -65,7 +66,7 @@ export default function ContactPageClient({
           <h2 className="text-4xl md:text-5xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent">
             {title}
           </h2>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">{subtitle}</p>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">{subtitle}</p>
         </motion.div>
 
         <motion.div
@@ -101,10 +102,10 @@ export default function ContactPageClient({
                     <h3 className="font-medium text-lg group-hover/link:text-primary transition-colors">
                       {link.title}
                     </h3>
-                    <p className="text-gray-600">{link.description}</p>
+                    <p className="text-muted-foreground">{link.description}</p>
                   </div>
 
-                  <ArrowUpRight className="h-5 w-5 text-gray-600 opacity-0 group-hover/link:opacity-100 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5 transition-all" />
+                  <ArrowUpRight className="h-5 w-5 text-muted-foreground opacity-0 group-hover/link:opacity-100 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5 transition-all" />
                 </motion.a>
               ))}
             </div>

--- a/src/app/[locale]/(web)/add-community/page.client.tsx
+++ b/src/app/[locale]/(web)/add-community/page.client.tsx
@@ -64,7 +64,7 @@ export default function AddCommunityPageClient({
           <h1 className="text-4xl md:text-5xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent">
             {title}
           </h1>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">{subtitle}</p>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">{subtitle}</p>
         </motion.div>
 
         <motion.div
@@ -81,7 +81,7 @@ export default function AddCommunityPageClient({
                 <span className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-primary/10 text-primary font-medium transition-colors group-hover/item:bg-primary/20">
                   {index + 1}
                 </span>
-                <span className="flex-1 pt-1 text-gray-600 group-hover/item:text-foreground transition-colors">
+                <span className="flex-1 pt-1 text-muted-foreground group-hover/item:text-foreground transition-colors">
                   {step}
                 </span>
               </motion.li>
@@ -89,7 +89,7 @@ export default function AddCommunityPageClient({
           </ol>
 
           <div className="space-y-6">
-            <p className="text-lg text-gray-600">{instructions}</p>
+            <p className="text-lg text-muted-foreground">{instructions}</p>
 
             <Button
               asChild

--- a/src/app/[locale]/(web)/communities/_components/card.tsx
+++ b/src/app/[locale]/(web)/communities/_components/card.tsx
@@ -128,12 +128,12 @@ export function CommunityCard({ community }: { community: Community }) {
             <h3 className="text-xl font-semibold tracking-tight group-hover:text-primary transition-colors">
               {community.name}
             </h3>
-            <p className="text-sm text-gray-600 flex items-center gap-1.5">
+            <p className="text-sm text-muted-foreground flex items-center gap-1.5">
               <MapPin className="h-3.5 w-3.5" />
               {community.province}
             </p>
           </div>
-          <p className="text-sm text-gray-600 line-clamp-3 group-hover:text-gray-600/80 transition-colors">
+          <p className="text-sm text-muted-foreground line-clamp-3 group-hover:text-muted-foreground/80 transition-colors">
             {community.shortDescription}
           </p>
         </CardContent>

--- a/src/app/[locale]/(web)/communities/page.client.tsx
+++ b/src/app/[locale]/(web)/communities/page.client.tsx
@@ -87,7 +87,7 @@ export default function CommunitiesPageClient({
               <h2 className="text-4xl md:text-5xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-primary to-accent">
                 {t("title")}
               </h2>
-              <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+              <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
                 {t("subtitle")}
               </p>
             </div>

--- a/src/app/[locale]/(web)/communities/page.tsx
+++ b/src/app/[locale]/(web)/communities/page.tsx
@@ -1,7 +1,9 @@
 import { routing, type Locale } from "@/i18n/routing";
-import { setRequestLocale } from "next-intl/server";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import type { Metadata } from "next";
 
 import { fetchCommunities } from "@/lib/fetch-communities";
+import { metadata as metadataConstants } from "@/constants/metadata";
 import CommunitiesPageClient from "./page.client";
 
 type Props = {
@@ -10,6 +12,44 @@ type Props = {
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Communities" });
+
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    keywords: [
+      ...metadataConstants.keywords,
+      "meetups",
+      "events",
+      "networking",
+      "developers",
+    ],
+    openGraph: {
+      ...metadataConstants.openGraph,
+      title: t("metaTitle"),
+      description: t("metaDescription"),
+      url: `https://techhubs.es/${locale}/communities`,
+      locale: locale === "es" ? "es_ES" : "en_US",
+    },
+    twitter: {
+      ...metadataConstants.twitter,
+      title: t("metaTitle"),
+      description: t("metaDescription"),
+    },
+    alternates: {
+      canonical: "https://techhubs.es/communities",
+      languages: {
+        "es": "https://techhubs.es/es/communities",
+        "en": "https://techhubs.es/en/communities",
+        "x-default": "https://techhubs.es/es/communities",
+      },
+    },
+    robots: metadataConstants.robots,
+  };
 }
 
 export default async function CommunitiesPage({ params }: Props) {

--- a/src/app/[locale]/(web)/community/[slug]/_components/content/Header.tsx
+++ b/src/app/[locale]/(web)/community/[slug]/_components/content/Header.tsx
@@ -28,7 +28,7 @@ export default function CommunityHeader({
         <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-primary">
           {name}
         </h1>
-        <div className="flex items-center gap-2 text-gray-600">
+        <div className="flex items-center gap-2 text-muted-foreground">
           <MapPin className="h-4 w-4" />
           <span>{province}</span>
         </div>
@@ -38,7 +38,7 @@ export default function CommunityHeader({
       </Badge>
       <div className="space-y-4">
         <h2 className="text-xl font-semibold tracking-tight">Description</h2>
-        <p className="text-base text-gray-600 leading-relaxed">
+        <p className="text-base text-muted-foreground leading-relaxed">
           {fullDescription}
         </p>
       </div>

--- a/src/app/[locale]/(web)/community/[slug]/page.tsx
+++ b/src/app/[locale]/(web)/community/[slug]/page.tsx
@@ -1,54 +1,103 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { routing, type Locale } from "@/i18n/routing";
+import { getTranslations } from "next-intl/server";
+
+import CommunityContent from "./_components/content";
 import {
   fetchCommunities,
   fetchCommunityBySlug,
 } from "@/lib/fetch-communities";
-import CommunityContent from "./_components/content";
-import { notFound } from "next/navigation";
-import type { Metadata } from "next";
+
+import { metadata as metadataConstants } from "@/constants/metadata";
+
+type Props = {
+  params: Promise<{ slug: string; locale: Locale }>;
+};
 
 export const generateStaticParams = async () => {
   const communities = fetchCommunities();
-  return communities.map((community) => ({
-    slug: community.slug,
-  }));
+  const paths: { slug: string; locale: Locale }[] = [];
+
+  routing.locales.forEach((locale) => {
+    communities.forEach((community) => {
+      paths.push({ slug: community.slug, locale });
+    });
+  });
+
+  return paths;
 };
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}): Promise<Metadata> {
-  const { slug } = await params;
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug, locale } = await params;
   const community = fetchCommunityBySlug(slug);
+  const t = await getTranslations({ locale, namespace: "Community" });
 
   if (!community) {
     return {
-      title: "Community Not Found",
-      description: "The requested community could not be found.",
+      title: t("notFoundTitle"),
+      description: t("notFoundDescription"),
+      robots: {
+        index: false,
+        follow: false,
+      },
     };
   }
 
+  const truncatedDescription =
+    community.shortDescription.length > 150
+      ? community.shortDescription.substring(0, 147) + "..."
+      : community.shortDescription;
+
+  const metaTitle = t("metaTitle", {
+    name: community.name,
+    province: community.province,
+  });
+
+  const metaDescription = t("metaDescription", {
+    name: community.name,
+    category: community.category,
+    province: community.province,
+    description: truncatedDescription,
+  });
+
+  const communityKeywords = [
+    community.name.toLowerCase(),
+    community.category.toLowerCase(),
+    community.province.toLowerCase(),
+    "meetup",
+    "networking",
+  ];
+
   return {
-    title: `${community.name} - Tech Community in ${community.province}`,
-    description: community.shortDescription,
+    title: metaTitle,
+    description: metaDescription,
+    keywords: [...metadataConstants.keywords, ...communityKeywords],
     openGraph: {
-      title: `${community.name} - Tech Community in ${community.province}`,
-      description: community.shortDescription,
-      type: "website",
+      ...metadataConstants.openGraph,
+      title: metaTitle,
+      description: metaDescription,
+      url: `https://techhubs.es/${locale}/community/${slug}`,
+      locale: locale === "es" ? "es_ES" : "en_US",
     },
     twitter: {
-      card: "summary",
-      title: `${community.name} - Tech Community in ${community.province}`,
-      description: community.shortDescription,
+      ...metadataConstants.twitter,
+      title: metaTitle,
+      description: metaDescription,
     },
+    alternates: {
+      canonical: `https://techhubs.es/community/${slug}`,
+      languages: {
+        "es": `https://techhubs.es/es/community/${slug}`,
+        "en": `https://techhubs.es/en/community/${slug}`,
+        "x-default": `https://techhubs.es/es/community/${slug}`,
+      },
+    },
+    robots: metadataConstants.robots,
   };
 }
 
-export default async function CommunityPage({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
+export default async function CommunityPage({ params }: Props) {
   const { slug } = await params;
   const community = fetchCommunityBySlug(slug);
   if (!community) {

--- a/src/app/[locale]/(web)/community/[slug]/page.tsx
+++ b/src/app/[locale]/(web)/community/[slug]/page.tsx
@@ -58,10 +58,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const communityKeywords = [
     community.name.toLowerCase(),
-    community.category.toLowerCase(),
+    community.category.toLowerCase().replace(/\s+/g, '-'),
     community.province.toLowerCase(),
     "meetup",
     "networking",
+    "developers",
+    "tech-community",
   ];
 
   return {
@@ -95,6 +97,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function CommunityPage({ params }: Props) {
   const { slug } = await params;
   const community = fetchCommunityBySlug(slug);
+  
   if (!community) {
     notFound();
   }

--- a/src/app/[locale]/(web)/community/[slug]/page.tsx
+++ b/src/app/[locale]/(web)/community/[slug]/page.tsx
@@ -44,11 +44,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const truncatedDescription =
-    community.shortDescription.length > 150
-      ? community.shortDescription.substring(0, 147) + "..."
-      : community.shortDescription;
-
   const metaTitle = t("metaTitle", {
     name: community.name,
     province: community.province,
@@ -58,7 +53,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     name: community.name,
     category: community.category,
     province: community.province,
-    description: truncatedDescription,
+    description: community.shortDescription,
   });
 
   const communityKeywords = [

--- a/src/app/[locale]/(web)/events/_components/event-card.tsx
+++ b/src/app/[locale]/(web)/events/_components/event-card.tsx
@@ -90,7 +90,7 @@ const EventCard = memo(({ event, variants }: EventCardProps) => {
       <div className="p-6 flex flex-col flex-1">
         <div className="flex items-center gap-2 mb-3" aria-label={t("date")}>
           <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-          <span className="text-gray-600 text-sm font-medium">
+          <span className="text-muted-foreground text-sm font-medium">
             {event.date}
           </span>
         </div>
@@ -99,12 +99,12 @@ const EventCard = memo(({ event, variants }: EventCardProps) => {
           {event.title}
         </h4>
 
-        <p className="text-gray-600 text-sm mb-4 line-clamp-3 flex-1">
+        <p className="text-muted-foreground text-sm mb-4 line-clamp-3 flex-1">
           {event.description}
         </p>
 
         <div className="flex items-center justify-between mb-4">
-          <span className="text-gray-600 text-sm">
+          <span className="text-muted-foreground text-sm">
             {t("by")}{" "}
             <span className="font-medium text-foreground">{event.host}</span>
           </span>
@@ -116,12 +116,12 @@ const EventCard = memo(({ event, variants }: EventCardProps) => {
             <div className="w-6 h-6 bg-muted rounded-full flex items-center justify-center">
               <MapPin className="w-4 h-4" />
             </div>
-            <span className="text-gray-600 text-sm">{event.location}</span>
+            <span className="text-muted-foreground text-sm">{event.location}</span>
           </div>
 
           <div className="pt-4 border-t border-border">
             <div className="flex items-center justify-between">
-              <span className="text-gray-600 text-sm">{t("viewEvent")}</span>
+              <span className="text-muted-foreground text-sm">{t("viewEvent")}</span>
               <ChevronRight className="w-4 h-4" />
             </div>
           </div>

--- a/src/app/[locale]/(web)/events/_components/events-list.tsx
+++ b/src/app/[locale]/(web)/events/_components/events-list.tsx
@@ -47,7 +47,7 @@ const EventsList = memo(({ events }: EventsListProps) => {
           <h3 className="text-3xl md:text-4xl font-bold tracking-tight text-primary">
             {t("next")}
           </h3>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
             {t("nextDescription")}
           </p>
         </motion.div>

--- a/src/app/[locale]/(web)/events/_components/hero-section.tsx
+++ b/src/app/[locale]/(web)/events/_components/hero-section.tsx
@@ -67,7 +67,7 @@ const HeroSection = memo(
                 </h2>
               </div>
 
-              <p className="text-lg text-gray-600 max-w-2xl">{t("subtitle")}</p>
+              <p className="text-lg text-muted-foreground max-w-2xl">{t("subtitle")}</p>
             </div>
 
             <motion.div

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -79,7 +79,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description: t("subtitle"),
       url: "https://techhubs.es",
       siteName: "TechHubs Spain",
-      locale: locale,
+      locale: locale === "es" ? "es_ES" : "en_US",
       type: "website",
     },
     twitter: {
@@ -87,6 +87,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `${t("title")} ${t("country")}`,
       description: t("subtitle"),
     },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    metadataBase: new URL('https://techhubs.es'),
   };
 }
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -91,7 +91,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       index: true,
       follow: true,
     },
-    metadataBase: new URL('https://techhubs.es'),
+    metadataBase: new URL("https://techhubs.es"),
   };
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,7 +56,7 @@
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(44.6% 0.03 256.802);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,30 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = "https://techhubs.es";
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/_next/", "/admin/", "/.well-known/", "/private/"],
+      },
+      {
+        userAgent: "*",
+        allow: "/es/",
+      },
+      {
+        userAgent: "*",
+        allow: "/en/",
+      },
+      {
+        userAgent: "Googlebot",
+        allow: "/",
+        crawlDelay: 1,
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,102 @@
+import { MetadataRoute } from "next";
+import { fetchCommunities } from "@/lib/fetch-communities";
+import { routing } from "@/i18n/routing";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://techhubs.es";
+  const currentDate = new Date();
+  const communities = fetchCommunities();
+
+  const staticRoutes = [
+    {
+      path: "",
+      priority: 1.0,
+      changeFreq: "weekly" as const,
+    },
+    {
+      path: "/communities",
+      priority: 0.9,
+      changeFreq: "daily" as const,
+    },
+    {
+      path: "/events",
+      priority: 0.8,
+      changeFreq: "daily" as const,
+    },
+    {
+      path: "/about",
+      priority: 0.7,
+      changeFreq: "monthly" as const,
+    },
+    {
+      path: "/contact",
+      priority: 0.6,
+      changeFreq: "monthly" as const,
+    },
+    {
+      path: "/add-community",
+      priority: 0.5,
+      changeFreq: "monthly" as const,
+    },
+  ];
+
+  const sitemapEntries: MetadataRoute.Sitemap = [];
+
+  sitemapEntries.push({
+    url: baseUrl,
+    lastModified: currentDate,
+    changeFrequency: "weekly",
+    priority: 1.0,
+    alternates: {
+      languages: routing.locales.reduce(
+        (acc, locale) => {
+          acc[locale] = `${baseUrl}/${locale}`;
+          return acc;
+        },
+        {} as Record<string, string>,
+      ),
+    },
+  });
+
+  routing.locales.forEach((locale) => {
+    staticRoutes.forEach((route) => {
+      sitemapEntries.push({
+        url: `${baseUrl}/${locale}${route.path}`,
+        lastModified: currentDate,
+        changeFrequency: route.changeFreq,
+        priority: route.priority,
+        alternates: {
+          languages: routing.locales.reduce(
+            (acc, loc) => {
+              acc[loc] = `${baseUrl}/${loc}${route.path}`;
+              return acc;
+            },
+            {} as Record<string, string>,
+          ),
+        },
+      });
+    });
+  });
+
+  routing.locales.forEach((locale) => {
+    communities.forEach((community) => {
+      sitemapEntries.push({
+        url: `${baseUrl}/${locale}/community/${community.slug}`,
+        lastModified: currentDate,
+        changeFrequency: "weekly",
+        priority: 0.8,
+        alternates: {
+          languages: routing.locales.reduce(
+            (acc, loc) => {
+              acc[loc] = `${baseUrl}/${loc}/community/${community.slug}`;
+              return acc;
+            },
+            {} as Record<string, string>,
+          ),
+        },
+      });
+    });
+  });
+
+  return sitemapEntries;
+}

--- a/src/components/common/footer.tsx
+++ b/src/components/common/footer.tsx
@@ -23,7 +23,7 @@ export default function Footer() {
             <h3 className="text-lg font-semibold tracking-tight">
               {t("about")}
             </h3>
-            <p className="text-sm leading-relaxed text-gray-600">
+            <p className="text-sm leading-relaxed text-muted-foreground">
               {t("aboutDescription")}
             </p>
           </div>
@@ -42,7 +42,7 @@ export default function Footer() {
                   <Link
                     href={href}
                     className={cn(
-                      "text-sm text-gray-600",
+                      "text-sm text-muted-foreground",
                       "hover:text-primary transition-colors duration-200",
                       "flex items-center gap-2"
                     )}
@@ -64,7 +64,7 @@ export default function Footer() {
               rel="noopener noreferrer"
               className={cn(
                 "group flex items-center gap-2",
-                "text-sm text-gray-600",
+                "text-sm text-muted-foreground",
                 "hover:text-primary transition-colors duration-200"
               )}
             >
@@ -75,7 +75,7 @@ export default function Footer() {
         </div>
 
         <div className="mt-8 pt-6 border-t border-border/50">
-          <p className="text-center text-sm text-gray-600">
+          <p className="text-center text-sm text-muted-foreground">
             {t("copyright", { year: new Date().getFullYear() })}
           </p>
         </div>

--- a/src/components/common/not-found-content.tsx
+++ b/src/components/common/not-found-content.tsx
@@ -77,7 +77,7 @@ const HelpText = memo(() => {
 
   return (
     <div className="pt-8">
-      <p className="text-sm text-gray-600 drop-shadow-sm">
+      <p className="text-sm text-muted-foreground drop-shadow-sm">
         Looking for something specific?{" "}
         <Link
           href="/communities"
@@ -156,7 +156,7 @@ const NotFoundContent = memo(
                 </span>
               </h1>
 
-              <p className="text-lg md:text-xl text-gray-600 leading-relaxed max-w-prose mx-auto drop-shadow-sm">
+              <p className="text-lg md:text-xl text-muted-foreground leading-relaxed max-w-prose mx-auto drop-shadow-sm">
                 {description}
               </p>
             </header>

--- a/src/components/spain-map.tsx
+++ b/src/components/spain-map.tsx
@@ -303,7 +303,7 @@ export default function SpainMap({
             }}
           >
             <button
-              className="absolute top-1 right-1 text-gray-600 hover:text-foreground transition-colors"
+              className="absolute top-1 right-1 text-muted-foreground hover:text-foreground transition-colors"
               onClick={closeTooltip}
               aria-label="Close tooltip"
             >
@@ -314,7 +314,7 @@ export default function SpainMap({
                 <p className="font-medium text-sm text-popover-foreground">
                   {tooltipContent.community.name}
                 </p>
-                <p className="text-xs flex items-center gap-1 text-gray-600">
+                <p className="text-xs flex items-center gap-1 text-muted-foreground">
                   <span className="w-2 h-2 rounded-full bg-primary" />
                   {tooltipContent.community.province}
                 </p>
@@ -342,7 +342,7 @@ export default function SpainMap({
                     <p className="font-medium text-sm text-popover-foreground">
                       {comm.name}
                     </p>
-                    <p className="text-xs text-gray-600">{comm.province}</p>
+                    <p className="text-xs text-muted-foreground">{comm.province}</p>
                   </div>
                 ))}
               </div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-gray-600 text-sm", className)}
+      className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
   );

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-gray-600 [&_svg:not([class*='text-'])]:text-gray-600 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -92,7 +92,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("text-gray-600 px-2 py-1.5 text-xs", className)}
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
       {...props}
     />
   );
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-gray-600 relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -121,7 +121,7 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-gray-600 text-sm", className)}
+      className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
   );

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-gray-600 inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-gray-600 inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## Overview of changes

This PR enhances the SEO capabilities of the TechHubs España platform with comprehensive metadata support, internationalization improvements, and accessibility fixes. The changes include:

- **Enhanced SEO metadata**: Added proper meta titles, descriptions, and Open Graph tags for community pages and listings
- **Internationalization support**: Implemented locale-aware metadata generation with proper hreflang and canonical URLs
- **SEO infrastructure**: Added robots.txt and sitemap.xml generation for better search engine crawling
- **Accessibility improvements**: Fixed color contrast issues by replacing hardcoded gray colors with CSS custom properties
- **Lighthouse optimization**: Resolved meta description issues that were causing SEO audit failures

## Questions/Notes for reviewers
- The main fix addresses a critical SEO issue where Lighthouse audits weren't properly recognizing meta descriptions
- Color accessibility changes replace `text-gray-600` with `text-muted-foreground` throughout the codebase - this is a visual consistency improvement with no functional impact, as the `text-muted-foreground` OKLCH value was updated to `text-gray-600` on light mode (globals.css change)
- Text colors should remain the same on light mode, only dark mode was improved
- The metadata spreading pattern was simplified to avoid potential conflicts with Next.js metadata merging
- All SEO-related files (robots.ts, sitemap.ts) follow Next.js App Router conventions

## How to test/demonstrate
1. **SEO Testing**: 
   - Go to the community slug page, for example `/es/community/madridjs`, check that meta descriptions appear properly in browser dev tools under `<body>`, as expected by the [Streaming Metadata](https://nextjs.org/blog/next-15-2#streaming-metadata) feature by Next.js 15.
   
2. **Internationalization**:
   - Visit `/es/community/madridjs` and `/en/community/madridjs` 
   - Verify different meta titles/descriptions based on locale
   - Check hreflang tags in page source
   
3. **SEO Infrastructure**:
   - Visit `/robots.txt` and `/sitemap.xml` to verify proper generation
   - Check that the sitemap includes all community pages with proper locale variants

4. **Accessibility**:
   - Test dark/light mode switching to ensure text remains readable
   - Verify color contrast improvements across all pages

## Attachments

### Before:
Communities
<img width="1440" height="900" alt="Captura de pantalla 2025-07-29 a la(s) 16 12 43" src="https://github.com/user-attachments/assets/f262af56-4272-4494-a692-8cf5575bdc6a" />
Community Slug
<img width="1440" height="900" alt="Captura de pantalla 2025-07-29 a la(s) 16 12 59" src="https://github.com/user-attachments/assets/cae1114d-6b22-4381-a14d-1297d92f01c4" />

### After:
Communities
<img width="1440" height="900" alt="Communities after" src="https://github.com/user-attachments/assets/e61a598b-6b48-4ef0-9078-c558922fd884" />
Community Slug
<img width="1440" height="900" alt="Community Slug after" src="https://github.com/user-attachments/assets/be5c3afa-1a33-4d41-b999-bb69420f135f" />